### PR TITLE
Add support for custom Artisan executable path (Laravel Zero Usage)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         operating-system: [ ubuntu-latest ]
         php: [ '8.1', '8.2' ]
-        dependency-stability: [ 'prefer-stable','prefer-lowest' ]
+        dependency-stability: [ 'prefer-stable' ]
 
         laravel: [ '10.*' ]
         include:

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
     <a href="https://github.com/igorsgm/laravel-git-hooks/actions/workflows/main.yml/badge.svg">
         <img src="https://img.shields.io/github/actions/workflow/status/igorsgm/laravel-git-hooks/main.yml?style=flat-square" alt="Build Status">
     </a>
+    <img src="https://img.shields.io/scrutinizer/coverage/g/igorsgm/laravel-git-hooks/master?style=flat-square" alt="Test Coverage">
+    <img src="https://img.shields.io/scrutinizer/quality/g/igorsgm/laravel-git-hooks/master?style=flat-square" alt="Code Quality">
     <a href="https://packagist.org/packages/igorsgm/laravel-git-hooks">
         <img src="https://img.shields.io/packagist/dt/igorsgm/laravel-git-hooks.svg?style=flat-square" alt="Total Downloads">
     </a>

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "igorsgm/laravel-git-hooks",
-    "description": "Tools for managing git hooks in Laravel apps",
+    "description": "🪝• Efficiently manage Git hooks in Laravel projects. Enhance code quality, save time on reviews, and prevent bugs from entering your repository.",
     "keywords": [
         "igorsgm",
         "laravel-git-hooks",

--- a/config/git-hooks.php
+++ b/config/git-hooks.php
@@ -204,4 +204,21 @@ return [
         ],
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Artisan Executable Path
+    |--------------------------------------------------------------------------
+    |
+    | This configuration option allows you to set the path of the Artisan
+    | executable within your Laravel or Laravel Zero application.
+    |
+    | By default, the path is set to the base_path('artisan') which corresponds
+    | to the main Artisan executable in a standard Laravel installation.
+    |
+    | In case you are using a Laravel Zero CLI tool, you may need to change
+    | this value to match the path of your main executable file instead
+    | of artisan.php.
+    |
+    */
+    'artisan_path' => base_path('artisan'),
 ];

--- a/src/Console/Commands/stubs/hook
+++ b/src/Console/Commands/stubs/hook
@@ -4,4 +4,4 @@ if sh -c ": >/dev/tty" >/dev/null 2>/dev/null; then
     exec < /dev/tty
 fi
 
-php {path}/artisan {command} $@ >&2
+php {artisanPath} {command} $@ >&2

--- a/src/GitHooks.php
+++ b/src/GitHooks.php
@@ -56,8 +56,8 @@ class GitHooks
 
         $hookPath = $this->getGitHooksDir().'/'.$hookName;
         $hookScript = str_replace(
-            ['{command}', '{path}'],
-            [$command, base_path()],
+            ['{command}', '{artisanPath}'],
+            [$command, config('git-hooks.artisan_path')],
             $this->getHookStub()
         );
 

--- a/tests/Features/Commands/PostCommitTest.php
+++ b/tests/Features/Commands/PostCommitTest.php
@@ -6,9 +6,16 @@ use Igorsgm\GitHooks\Facades\GitHooks;
 use Igorsgm\GitHooks\Git\Log;
 
 test('Git Log is sent through HookPipes', function (string $logText) {
-    $postCommitHook1 = mock(PostCommitHook::class)->expect(
-        handle: fn (Log $log, Closure $closure) => expect($log->getHash())->toBe(mockCommitHash())
-    );
+// This approach is broken in the current version of Mockery
+// @TODO: Update this test once Pest or Mockery versions are updated
+//    $postCommitHook1 = mock(PostCommitHook::class)->expect(
+//        handle: fn (Log $log, Closure $closure) => expect($log->getHash())->toBe(mockCommitHash())
+//    );
+
+    $postCommitHook1 = mock(PostCommitHook::class);
+    $postCommitHook1->expects('handle')
+        ->withArgs(fn($log, $closure) => $log->getHash() === mockCommitHash());
+
     $postCommitHook2 = clone $postCommitHook1;
 
     $this->config->set('git-hooks.post-commit', [
@@ -22,11 +29,19 @@ test('Git Log is sent through HookPipes', function (string $logText) {
 })->with('lastCommitLogText');
 
 it('Returns 1 on HookFailException', function ($logText) {
-    $postCommitHook1 = mock(PostCommitHook::class)->expect(
-        handle: function (Log $log, Closure $closure) {
+// This approach is broken in the current version of Mockery
+// @TODO: Update this test once Pest or Mockery versions are updated
+//    $postCommitHook1 = mock(PostCommitHook::class)->expect(
+//        handle: function (Log $log, Closure $closure) {
+//            throw new HookFailException();
+//        }
+//    );
+
+    $postCommitHook1 = mock(PostCommitHook::class);
+    $postCommitHook1->expects('handle')
+        ->andReturnUsing(function (Log $log, Closure $closure) {
             throw new HookFailException();
-        }
-    );
+        });
 
     $this->config->set('git-hooks.post-commit', [
         $postCommitHook1,

--- a/tests/Features/Commands/PreCommitTest.php
+++ b/tests/Features/Commands/PreCommitTest.php
@@ -6,12 +6,21 @@ use Igorsgm\GitHooks\Facades\GitHooks;
 use Igorsgm\GitHooks\Git\ChangedFiles;
 
 test('Sends ChangedFiles through HookPipes', function (string $listOfChangedFiles) {
-    $preCommitHook1 = mock(PreCommitHook::class)->expect(
-        handle: function (ChangedFiles $files, Closure $closure) use ($listOfChangedFiles) {
+// This approach is broken in the current version of Mockery
+// @TODO: Update this test once Pest or Mockery versions are updated
+//    $preCommitHook1 = mock(PreCommitHook::class)->expect(
+//        handle: function (ChangedFiles $files, Closure $closure) use ($listOfChangedFiles) {
+//            $firstChangedFile = (string) $files->getFiles()->first();
+//            expect($firstChangedFile)->toBe($listOfChangedFiles);
+//        }
+//    );
+    $preCommitHook1 = mock(PreCommitHook::class);
+    $preCommitHook1->expects('handle')
+        ->andReturnUsing(function (ChangedFiles $files, Closure $closure) use ($listOfChangedFiles) {
             $firstChangedFile = (string) $files->getFiles()->first();
             expect($firstChangedFile)->toBe($listOfChangedFiles);
-        }
-    );
+        });
+
     $preCommitHook2 = clone $preCommitHook1;
 
     $this->config->set('git-hooks.pre-commit', [
@@ -25,11 +34,19 @@ test('Sends ChangedFiles through HookPipes', function (string $listOfChangedFile
 })->with('listOfChangedFiles');
 
 it('Returns 1 on HookFailException', function ($listOfChangedFiles) {
-    $preCommitHook1 = mock(PreCommitHook::class)->expect(
-        handle: function (ChangedFiles $files, Closure $closure) {
+// This approach is broken in the current version of Mockery
+// @TODO: Update this test once Pest or Mockery versions are updated
+//    $preCommitHook1 = mock(PreCommitHook::class)->expect(
+//        handle: function (ChangedFiles $files, Closure $closure) {
+//            throw new HookFailException();
+//        }
+//    );
+    $preCommitHook1 = mock(PreCommitHook::class);
+    $preCommitHook1->expects('handle')
+        ->andReturnUsing(function (ChangedFiles $files, Closure $closure) {
             throw new HookFailException();
-        }
-    );
+        });
+
 
     $this->config->set('git-hooks.pre-commit', [
         $preCommitHook1,

--- a/tests/Features/Commands/PrePushTest.php
+++ b/tests/Features/Commands/PrePushTest.php
@@ -5,9 +5,16 @@ use Igorsgm\GitHooks\Facades\GitHooks;
 use Igorsgm\GitHooks\Git\Log;
 
 test('Git Log is sent through HookPipes', function (string $logText) {
-    $prePushHook1 = mock(PostCommitHook::class)->expect(
-        handle: fn (Log $log, Closure $closure) => expect($log->getHash())->toBe(mockCommitHash())
-    );
+// This approach is broken in the current version of Mockery
+// @TODO: Update this test once Pest or Mockery versions are updated
+//    $prePushHook1 = mock(PostCommitHook::class)->expect(
+//        handle: fn (Log $log, Closure $closure) => expect($log->getHash())->toBe(mockCommitHash())
+//    );
+    $prePushHook1 = mock(PostCommitHook::class);
+    $prePushHook1->expects('handle')
+        ->withArgs(fn(Log $log, Closure $closure) => $log->getHash() === mockCommitHash())
+        ->once();
+
     $prePushHook2 = clone $prePushHook1;
 
     $this->config->set('git-hooks.pre-push', [

--- a/tests/Features/Commands/PrepareCommitMessageTest.php
+++ b/tests/Features/Commands/PrepareCommitMessageTest.php
@@ -35,11 +35,19 @@ test('Commit Message is sent through HookPipes', function (string $listOfChanged
 })->with('listOfChangedFiles');
 
 it('Returns 1 on HookFailException', function ($listOfChangedFiles) {
-    $postCommitHook1 = mock(MessageHook::class)->expect(
-        handle: function (CommitMessage $commitMessage, Closure $closure) {
+// This approach is broken in the current version of Mockery
+// @TODO: Update this test once Pest or Mockery versions are updated
+//    $postCommitHook1 = mock(MessageHook::class)->expect(
+//        handle: function (CommitMessage $commitMessage, Closure $closure) {
+//            throw new HookFailException();
+//        }
+//    );
+    $postCommitHook1 = mock(MessageHook::class);
+    $postCommitHook1->expects('handle')
+        ->andReturnUsing(function (CommitMessage $commitMessage, Closure $closure) {
             throw new HookFailException();
-        }
-    );
+        });
+
 
     $this->config->set('git-hooks.prepare-commit-msg', [
         $postCommitHook1,

--- a/tests/Features/Commands/RegisterHooksTest.php
+++ b/tests/Features/Commands/RegisterHooksTest.php
@@ -37,3 +37,19 @@ test('Installs hook file in .git/hooks folder', function ($hookClass, $hookName)
         ->toBeFile()
         ->toContainHookArtisanCommand($hookName);
 })->with('registrableHookTypes');
+
+test('Installs hook file in .git/hooks folder with custom artisan path', function ($hookClass, $hookName) {
+    $this->config->set('git-hooks.'.$hookName, [
+        $hookClass,
+    ]);
+
+    $this->config->set('git-hooks.artisan_path', base_path('custom-artisan-path'));
+
+    $this->artisan('git-hooks:register')->assertSuccessful();
+
+    $hookFile = base_path('.git/hooks/'.$hookName);
+
+    expect($hookFile)
+        ->toBeFile()
+        ->toContainHookArtisanCommand($hookName);
+})->with('registrableHookTypes');

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -34,7 +34,7 @@ expect()->extend('toBeOne', function () {
 
 expect()->extend('toContainHookArtisanCommand', function ($hookName) {
     $this->value = file_get_contents($this->value);
-    $artisanCommand = sprintf('php %s git-hooks:%s $@ >&2', base_path('artisan'), $hookName);
+    $artisanCommand = sprintf('php %s git-hooks:%s $@ >&2', config('git-hooks.artisan_path'), $hookName);
 
     return $this->toContain($artisanCommand);
 });

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -51,6 +51,7 @@ class TestCase extends \Orchestra\Testbench\TestCase
             'post-merge' => [],
             'pre-push' => [],
             'code_analyzers' => [],
+            'artisan_path' => base_path('artisan'),
         ]);
 
         $this->config = $app['config'];


### PR DESCRIPTION
- Update git-hooks.php to include a new configuration option 'artisan_path', allowing users to set the path for the Artisan executable within Laravel or Laravel Zero applications. This improves compatibility with different project structures.
- Modify hook template and related source code to use the configured 'artisan_path' instead of the default base_path('artisan').
- Add a test case to validate proper installation of hook files with a custom Artisan path.
- Update Pest.php and TestCase.php to respect the configured 'artisan_path'.