### PR TITLE
Fix: Code Analyzer Hooks

### DIFF
--- a/src/Console/Commands/Hooks/BaseCodeAnalyzerPreCommitHook.php
+++ b/src/Console/Commands/Hooks/BaseCodeAnalyzerPreCommitHook.php
@@ -74,7 +74,7 @@ abstract class BaseCodeAnalyzerPreCommitHook
      */
     public function handleCommittedFiles(ChangedFiles $files, Closure $next)
     {
-        $commitFiles = $files->getAddedToCommit();
+        $commitFiles = $files->getStaged();
 
         if ($commitFiles->isEmpty() || GitHooks::isMergeInProgress()) {
             return $next($files);

--- a/tests/Features/Commands/Hooks/BaseCodeAnalyzerPreCommitHookTest.php
+++ b/tests/Features/Commands/Hooks/BaseCodeAnalyzerPreCommitHookTest.php
@@ -9,9 +9,9 @@ beforeEach(function () {
     $this->initializeTempDirectory(base_path('temp'));
 });
 
-test('Skips check if there are no files added to commit', function () {
+test('Skips check if there are no staged files in commit', function () {
     $changedFiles = mock(ChangedFiles::class)
-        ->shouldReceive('getAddedToCommit')
+        ->shouldReceive('getStaged')
         ->andReturn(collect())
         ->getMock();
 


### PR DESCRIPTION
- Update BaseCodeAnalyzerPreCommitHook.php to use getStaged() instead of getAddedToCommit() for better accuracy in obtaining commit files.
- Modify test descriptions and method calls in BaseCodeAnalyzerPreCommitHookTest.php to reflect the changes made to the main file.