### PR TITLE
Add a `git_hooks_path` config variable.

### DIFF
--- a/config/git-hooks.php
+++ b/config/git-hooks.php
@@ -290,4 +290,15 @@ return [
     |
     */
     'debug_commands' => false,
+
+   /*
+   |--------------------------------------------------------------------------
+   | Git hooks path
+   |--------------------------------------------------------------------------
+   |
+   | This configuration option allows you to configure where the git hooks
+   | are stored for this project, you might need to change this if you
+   | are using git submodules as part of a wider project.
+   */
+    'git_hooks_path' => base_path('.git'.DIRECTORY_SEPARATOR.'hooks'),
 ];

--- a/src/GitHooks.php
+++ b/src/GitHooks.php
@@ -84,6 +84,6 @@ class GitHooks
      */
     public function getGitHooksDir()
     {
-        return base_path('.git'.DIRECTORY_SEPARATOR.'hooks');
+        return config('git-hooks.git_hooks_path');
     }
 }


### PR DESCRIPTION
Add a `git_hooks_path` config variable that allows a user to point the package to the correct path to place githooks for their project. This should be a non breaking change for existing users.

**Motivation:**
I wasn't able to get the package working as I was installing it in a [git submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules) setup where the Laravel project was a submodule in a large project. In that context the correct path for the git hooks is higher in the directory structure. This PR gives package users the option to configure that path so they can use it with git submodules.
