### PR TITLE
fix: add optional arguments to signatures

### DIFF
--- a/src/Console/Commands/PrePush.php
+++ b/src/Console/Commands/PrePush.php
@@ -15,7 +15,7 @@ class PrePush extends Command implements HookCommand
      *
      * @var string
      */
-    protected $signature = 'git-hooks:pre-push';
+    protected $signature = 'git-hooks:pre-push {remote?} {url?}';
 
     /**
      * The console command description.

--- a/src/Console/Commands/PrepareCommitMessage.php
+++ b/src/Console/Commands/PrepareCommitMessage.php
@@ -15,7 +15,7 @@ class PrepareCommitMessage extends Command implements HookCommand
      *
      * @var string
      */
-    protected $signature = 'git-hooks:prepare-commit-msg {file}';
+    protected $signature = 'git-hooks:prepare-commit-msg {file} {type?} {sha?}';
 
     /**
      * The console command description.


### PR DESCRIPTION
If the commands are run with extra arguments without them being defined the command fails. This fix allows calling the `pre-push` and `prepare-commit-msg` hooks with all their arguments while still retaining the old behavior since the arguments are optional.

Reference: https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks

closes #31 #36