### PR TITLE
Add git worktree support

### DIFF
--- a/src/Console/Commands/Hooks/BaseCodeAnalyzerPreCommitHook.php
+++ b/src/Console/Commands/Hooks/BaseCodeAnalyzerPreCommitHook.php
@@ -71,7 +71,7 @@ abstract class BaseCodeAnalyzerPreCommitHook implements CodeAnalyzerPreCommitHoo
     {
         $this->setCwd(base_path());
 
-        $this->chunkSize = config('git-hooks.analyzer_chunk_size');
+        $this->chunkSize = config('git-hooks.analyzer_chunk_size', $this->chunkSize);
     }
 
     /**

--- a/src/GitHooks.php
+++ b/src/GitHooks.php
@@ -103,10 +103,22 @@ class GitHooks
      */
     public function getGitHooksDir(): string
     {
-        $gitCommonDir = rtrim((string) shell_exec('git -C '.escapeshellarg(base_path()).' rev-parse --git-common-dir 2>/dev/null'));
+        $basePath = base_path();
+        $output = rtrim((string) shell_exec('git -C '.escapeshellarg($basePath).' rev-parse --show-toplevel --git-common-dir 2>/dev/null'));
+        $lines = explode("\n", $output);
 
-        if ($gitCommonDir !== '' && is_dir($gitCommonDir)) {
-            return $gitCommonDir.DIRECTORY_SEPARATOR.'hooks';
+        if (count($lines) === 2) {
+            [$toplevel, $gitCommonDir] = $lines;
+
+            // Resolve relative paths (e.g. ".git") against base_path
+            if ($gitCommonDir !== '' && !str_starts_with($gitCommonDir, DIRECTORY_SEPARATOR)) {
+                $gitCommonDir = $basePath.DIRECTORY_SEPARATOR.$gitCommonDir;
+            }
+
+            // Verify git is rooted at base_path, not a parent directory
+            if (realpath($toplevel) === realpath($basePath) && is_dir($gitCommonDir)) {
+                return $gitCommonDir.DIRECTORY_SEPARATOR.'hooks';
+            }
         }
 
         return base_path('.git'.DIRECTORY_SEPARATOR.'hooks');

--- a/src/GitHooks.php
+++ b/src/GitHooks.php
@@ -99,9 +99,16 @@ class GitHooks
 
     /**
      * Returns the path to the git hooks directory.
+     * Uses git rev-parse to resolve the correct path in both regular repos and worktrees.
      */
     public function getGitHooksDir(): string
     {
+        $gitCommonDir = rtrim((string) shell_exec('git -C '.escapeshellarg(base_path()).' rev-parse --git-common-dir 2>/dev/null'));
+
+        if ($gitCommonDir !== '' && is_dir($gitCommonDir)) {
+            return $gitCommonDir.DIRECTORY_SEPARATOR.'hooks';
+        }
+
         return base_path('.git'.DIRECTORY_SEPARATOR.'hooks');
     }
 }

--- a/tests/Unit/GitHooksTest.php
+++ b/tests/Unit/GitHooksTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+use Igorsgm\GitHooks\GitHooks;
+
+beforeEach(function () {
+    $this->initializeGitAsTempDirectory();
+    $this->gitHooks = new GitHooks();
+});
+
+afterEach(function () {
+    $this->deleteTempDirectory();
+});
+
+test('getGitHooksDir returns .git/hooks path in a regular repo', function () {
+    chdir(base_path());
+
+    $result = $this->gitHooks->getGitHooksDir();
+
+    expect($result)->toEndWith(DIRECTORY_SEPARATOR.'hooks');
+    expect($result)->toContain('.git');
+});
+
+test('getGitHooksDir returns the common hooks dir in a git worktree', function () {
+    $mainRepoPath = base_path();
+    chdir($mainRepoPath);
+
+    // Create an initial commit so we can create a worktree
+    shell_exec('git -C '.escapeshellarg($mainRepoPath).' commit --allow-empty -m "init" 2>/dev/null');
+
+    // Create a worktree outside the main repo to avoid ambiguity
+    $worktreePath = sys_get_temp_dir().DIRECTORY_SEPARATOR.'worktree-test-'.uniqid();
+    shell_exec('git -C '.escapeshellarg($mainRepoPath).' worktree add '.escapeshellarg($worktreePath).' -b test-worktree 2>/dev/null');
+
+    // Point base_path() at the worktree
+    $this->app->setBasePath($worktreePath);
+    chdir($worktreePath);
+
+    $result = $this->gitHooks->getGitHooksDir();
+
+    // Should resolve to the main repo's .git/hooks, NOT the worktree's .git file
+    $expectedCommonHooksDir = $mainRepoPath.DIRECTORY_SEPARATOR.'.git'.DIRECTORY_SEPARATOR.'hooks';
+    expect($result)->toBe($expectedCommonHooksDir);
+
+    // Clean up worktree
+    $this->app->setBasePath($mainRepoPath);
+    chdir($mainRepoPath);
+    shell_exec('git -C '.escapeshellarg($mainRepoPath).' worktree remove '.escapeshellarg($worktreePath).' 2>/dev/null');
+});
+
+test('getGitHooksDir falls back to base_path .git/hooks when git command fails', function () {
+    // Use a directory that is not a git repo
+    $nonGitDir = sys_get_temp_dir().DIRECTORY_SEPARATOR.'non-git-'.uniqid();
+    mkdir($nonGitDir, 0755, true);
+
+    $this->app->setBasePath($nonGitDir);
+
+    $result = $this->gitHooks->getGitHooksDir();
+
+    expect($result)->toBe($nonGitDir.DIRECTORY_SEPARATOR.'.git'.DIRECTORY_SEPARATOR.'hooks');
+
+    // Clean up
+    rmdir($nonGitDir);
+    $this->app->setBasePath(base_path());
+});


### PR DESCRIPTION
## Summary
- Adds support for git worktrees by resolving the hooks directory from `.git` file when it's not a directory (worktree case)
- Includes tests for the worktree resolution logic
- Fixes edge case where default value was missing

## Test plan
- [x] Unit tests added for worktree detection
- [x] Existing tests still pass