### PR TITLE
Add defaults to config() calls to prevent null type errors

### DIFF
--- a/src/Console/Commands/Hooks/BladeFormatterPreCommitHook.php
+++ b/src/Console/Commands/Hooks/BladeFormatterPreCommitHook.php
@@ -24,10 +24,10 @@ class BladeFormatterPreCommitHook extends BaseCodeAnalyzerPreCommitHook implemen
     {
         $this->configParam = $this->configParam();
 
-        return $this->setFileExtensions(config('git-hooks.code_analyzers.blade_formatter.file_extensions'))
-            ->setAnalyzerExecutable(config('git-hooks.code_analyzers.blade_formatter.path'), true)
-            ->setRunInDocker(config('git-hooks.code_analyzers.blade_formatter.run_in_docker'))
-            ->setDockerContainer(config('git-hooks.code_analyzers.blade_formatter.docker_container'))
+        return $this->setFileExtensions(config('git-hooks.code_analyzers.blade_formatter.file_extensions', []))
+            ->setAnalyzerExecutable(config('git-hooks.code_analyzers.blade_formatter.path', ''), true)
+            ->setRunInDocker(config('git-hooks.code_analyzers.blade_formatter.run_in_docker', false))
+            ->setDockerContainer(config('git-hooks.code_analyzers.blade_formatter.docker_container', ''))
             ->handleCommittedFiles($files, $next);
     }
 

--- a/src/Console/Commands/Hooks/ESLintPreCommitHook.php
+++ b/src/Console/Commands/Hooks/ESLintPreCommitHook.php
@@ -27,10 +27,10 @@ class ESLintPreCommitHook extends BaseCodeAnalyzerPreCommitHook implements CodeA
     {
         $this->configParam = $this->configParam();
 
-        return $this->setFileExtensions(config('git-hooks.code_analyzers.eslint.file_extensions'))
-            ->setAnalyzerExecutable(config('git-hooks.code_analyzers.eslint.path'), true)
-            ->setRunInDocker(config('git-hooks.code_analyzers.eslint.run_in_docker'))
-            ->setDockerContainer(config('git-hooks.code_analyzers.eslint.docker_container'))
+        return $this->setFileExtensions(config('git-hooks.code_analyzers.eslint.file_extensions', []))
+            ->setAnalyzerExecutable(config('git-hooks.code_analyzers.eslint.path', ''), true)
+            ->setRunInDocker(config('git-hooks.code_analyzers.eslint.run_in_docker', false))
+            ->setDockerContainer(config('git-hooks.code_analyzers.eslint.docker_container', ''))
             ->handleCommittedFiles($files, $next);
     }
 

--- a/src/Console/Commands/Hooks/LarastanPreCommitHook.php
+++ b/src/Console/Commands/Hooks/LarastanPreCommitHook.php
@@ -27,10 +27,10 @@ class LarastanPreCommitHook extends BaseCodeAnalyzerPreCommitHook implements Cod
     {
         $this->configParam = $this->configParam();
 
-        return $this->setFileExtensions(config('git-hooks.code_analyzers.larastan.file_extensions'))
-            ->setAnalyzerExecutable(config('git-hooks.code_analyzers.larastan.path'))
-            ->setRunInDocker(config('git-hooks.code_analyzers.larastan.run_in_docker'))
-            ->setDockerContainer(config('git-hooks.code_analyzers.larastan.docker_container'))
+        return $this->setFileExtensions(config('git-hooks.code_analyzers.larastan.file_extensions', []))
+            ->setAnalyzerExecutable(config('git-hooks.code_analyzers.larastan.path', ''))
+            ->setRunInDocker(config('git-hooks.code_analyzers.larastan.run_in_docker', false))
+            ->setDockerContainer(config('git-hooks.code_analyzers.larastan.docker_container', ''))
             ->handleCommittedFiles($files, $next);
     }
 

--- a/src/Console/Commands/Hooks/PHPCSFixerPreCommitHook.php
+++ b/src/Console/Commands/Hooks/PHPCSFixerPreCommitHook.php
@@ -27,10 +27,10 @@ class PHPCSFixerPreCommitHook extends BaseCodeAnalyzerPreCommitHook implements C
     {
         $this->configParam = $this->configParam();
 
-        return $this->setFileExtensions(config('git-hooks.code_analyzers.php_cs_fixer.file_extensions'))
-            ->setAnalyzerExecutable(config('git-hooks.code_analyzers.php_cs_fixer.path'))
-            ->setRunInDocker(config('git-hooks.code_analyzers.php_cs_fixer.run_in_docker'))
-            ->setDockerContainer(config('git-hooks.code_analyzers.php_cs_fixer.docker_container'))
+        return $this->setFileExtensions(config('git-hooks.code_analyzers.php_cs_fixer.file_extensions', []))
+            ->setAnalyzerExecutable(config('git-hooks.code_analyzers.php_cs_fixer.path', ''))
+            ->setRunInDocker(config('git-hooks.code_analyzers.php_cs_fixer.run_in_docker', false))
+            ->setDockerContainer(config('git-hooks.code_analyzers.php_cs_fixer.docker_container', ''))
             ->handleCommittedFiles($files, $next);
     }
 

--- a/src/Console/Commands/Hooks/PHPCodeSnifferPreCommitHook.php
+++ b/src/Console/Commands/Hooks/PHPCodeSnifferPreCommitHook.php
@@ -27,11 +27,11 @@ class PHPCodeSnifferPreCommitHook extends BaseCodeAnalyzerPreCommitHook implemen
     {
         $this->configParam = $this->configParam();
 
-        return $this->setFileExtensions(config('git-hooks.code_analyzers.php_code_sniffer.file_extensions'))
-            ->setAnalyzerExecutable(config('git-hooks.code_analyzers.php_code_sniffer.phpcs_path'))
-            ->setFixerExecutable(config('git-hooks.code_analyzers.php_code_sniffer.phpcbf_path'))
-            ->setRunInDocker(config('git-hooks.code_analyzers.php_code_sniffer.run_in_docker'))
-            ->setDockerContainer(config('git-hooks.code_analyzers.php_code_sniffer.docker_container'))
+        return $this->setFileExtensions(config('git-hooks.code_analyzers.php_code_sniffer.file_extensions', []))
+            ->setAnalyzerExecutable(config('git-hooks.code_analyzers.php_code_sniffer.phpcs_path', ''))
+            ->setFixerExecutable(config('git-hooks.code_analyzers.php_code_sniffer.phpcbf_path', ''))
+            ->setRunInDocker(config('git-hooks.code_analyzers.php_code_sniffer.run_in_docker', false))
+            ->setDockerContainer(config('git-hooks.code_analyzers.php_code_sniffer.docker_container', ''))
             ->handleCommittedFiles($files, $next);
     }
 

--- a/src/Console/Commands/Hooks/PhpInsightsPreCommitHook.php
+++ b/src/Console/Commands/Hooks/PhpInsightsPreCommitHook.php
@@ -27,10 +27,10 @@ class PhpInsightsPreCommitHook extends BaseCodeAnalyzerPreCommitHook implements 
     {
         $this->configParam = $this->configParam();
 
-        return $this->setFileExtensions(config('git-hooks.code_analyzers.phpinsights.file_extensions'))
-            ->setAnalyzerExecutable(config('git-hooks.code_analyzers.phpinsights.path'), true)
-            ->setRunInDocker(config('git-hooks.code_analyzers.phpinsights.run_in_docker'))
-            ->setDockerContainer(config('git-hooks.code_analyzers.phpinsights.docker_container'))
+        return $this->setFileExtensions(config('git-hooks.code_analyzers.phpinsights.file_extensions', []))
+            ->setAnalyzerExecutable(config('git-hooks.code_analyzers.phpinsights.path', ''), true)
+            ->setRunInDocker(config('git-hooks.code_analyzers.phpinsights.run_in_docker', false))
+            ->setDockerContainer(config('git-hooks.code_analyzers.phpinsights.docker_container', ''))
             ->handleCommittedFiles($files, $next);
     }
 

--- a/src/Console/Commands/Hooks/PintPreCommitHook.php
+++ b/src/Console/Commands/Hooks/PintPreCommitHook.php
@@ -27,10 +27,10 @@ class PintPreCommitHook extends BaseCodeAnalyzerPreCommitHook implements CodeAna
     {
         $this->configParam = $this->configParam();
 
-        return $this->setFileExtensions(config('git-hooks.code_analyzers.laravel_pint.file_extensions'))
-            ->setAnalyzerExecutable(config('git-hooks.code_analyzers.laravel_pint.path'), true)
-            ->setRunInDocker(config('git-hooks.code_analyzers.laravel_pint.run_in_docker'))
-            ->setDockerContainer(config('git-hooks.code_analyzers.laravel_pint.docker_container'))
+        return $this->setFileExtensions(config('git-hooks.code_analyzers.laravel_pint.file_extensions', []))
+            ->setAnalyzerExecutable(config('git-hooks.code_analyzers.laravel_pint.path', ''), true)
+            ->setRunInDocker(config('git-hooks.code_analyzers.laravel_pint.run_in_docker', false))
+            ->setDockerContainer(config('git-hooks.code_analyzers.laravel_pint.docker_container', ''))
             ->handleCommittedFiles($files, $next);
     }
 

--- a/src/Console/Commands/Hooks/PrettierPreCommitHook.php
+++ b/src/Console/Commands/Hooks/PrettierPreCommitHook.php
@@ -27,10 +27,10 @@ class PrettierPreCommitHook extends BaseCodeAnalyzerPreCommitHook implements Cod
     {
         $this->configParam = $this->configParam();
 
-        return $this->setFileExtensions(config('git-hooks.code_analyzers.prettier.file_extensions'))
-            ->setAnalyzerExecutable(config('git-hooks.code_analyzers.prettier.path'), true)
-            ->setRunInDocker(config('git-hooks.code_analyzers.prettier.run_in_docker'))
-            ->setDockerContainer(config('git-hooks.code_analyzers.prettier.docker_container'))
+        return $this->setFileExtensions(config('git-hooks.code_analyzers.prettier.file_extensions', []))
+            ->setAnalyzerExecutable(config('git-hooks.code_analyzers.prettier.path', ''), true)
+            ->setRunInDocker(config('git-hooks.code_analyzers.prettier.run_in_docker', false))
+            ->setDockerContainer(config('git-hooks.code_analyzers.prettier.docker_container', ''))
             ->handleCommittedFiles($files, $next);
     }
 

--- a/src/Console/Commands/Hooks/RectorPreCommitHook.php
+++ b/src/Console/Commands/Hooks/RectorPreCommitHook.php
@@ -27,10 +27,10 @@ class RectorPreCommitHook extends BaseCodeAnalyzerPreCommitHook implements CodeA
     {
         $this->configParam = $this->configParam();
 
-        return $this->setFileExtensions(config('git-hooks.code_analyzers.rector.file_extensions'))
-            ->setAnalyzerExecutable(config('git-hooks.code_analyzers.rector.path'), true)
-            ->setRunInDocker(config('git-hooks.code_analyzers.rector.run_in_docker'))
-            ->setDockerContainer(config('git-hooks.code_analyzers.rector.docker_container'))
+        return $this->setFileExtensions(config('git-hooks.code_analyzers.rector.file_extensions', []))
+            ->setAnalyzerExecutable(config('git-hooks.code_analyzers.rector.path', ''), true)
+            ->setRunInDocker(config('git-hooks.code_analyzers.rector.run_in_docker', false))
+            ->setDockerContainer(config('git-hooks.code_analyzers.rector.docker_container', ''))
             ->handleCommittedFiles($files, $next);
     }
 


### PR DESCRIPTION
## Summary
- All hook `handle()` methods now provide sensible defaults for `file_extensions`, `path`, `run_in_docker`, and `docker_container` config values
- Prevents `TypeError` when config keys are missing or not set

## Test plan
- [x] Verified hooks work correctly with missing config values
- [x] No behaviour change when config values are present