### PR TITLE
Add Laravel 13 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -226,3 +226,107 @@ jobs:
 
       - name: Execute PHP Insights
         run: vendor/bin/phpinsights --disable-security-check --no-interaction
+
+  laravel13-tests:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        operating-system: [ ubuntu-latest ]
+        php: [ '8.3', '8.4' ]
+        dependency-stability: [ 'prefer-stable' ]
+
+        laravel: [ '13.*' ]
+        include:
+          - laravel: 13.*
+            testbench: 11.*
+
+    name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - ${{ matrix.dependency-stability }} - ${{ matrix.operating-system}}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+
+      - name: Cache node_modules directory
+        uses: actions/cache@v4
+        id: node_modules-cache
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-build-${{ hashFiles('**/package.json') }}-${{ hashFiles('**/package-lock.json') }}
+
+      - name: Install NPM packages
+        if: steps.node_modules-cache.outputs.cache-hit != 'true'
+        run: npm ci --include=dev
+
+      - name: Install PHP versions
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        id: actions-cache
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-laravel-13-${{ matrix.php }}-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-laravel-13-${{ matrix.php }}-
+
+      - name: Cache PHP dependencies (vendor)
+        uses: actions/cache@v4
+        id: vendor-cache
+        with:
+          path: vendor
+          key: ${{ runner.os }}-build-laravel-13-${{ matrix.php }}-${{ hashFiles('**/composer.lock') }}
+
+      - name: Install Laravel Dependencies
+        if: steps.vendor-cache.outputs.cache-hit != 'true'
+        run: |
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer update --${{ matrix.dependency-stability }} --prefer-dist --no-interaction
+
+      - name: Update Dependencies with latest stable
+        if: matrix.dependency-stability == 'prefer-stable'
+        run: composer update --prefer-stable
+
+      - name: Update Dependencies with lowest stable
+        if: matrix.dependency-stability == 'prefer-lowest'
+        run: composer update --prefer-stable --prefer-lowest
+
+      - name: Set up Git User
+        run: |
+          git config --global user.email "github-actions@example.com"
+          git config --global user.name "GitHub Actions"
+
+      # Code quality
+      - name: Execute tests (Unit and Feature tests) via PestPHP
+        shell: 'script -q -e -c "bash {0}"'
+        # Set environment
+        env:
+          SESSION_DRIVER: array
+          TTY: true
+
+        run: vendor/bin/pest
+
+      - name: Execute Code Sniffer via Laravel Pint
+        run: vendor/bin/pint --test src config
+
+      - name: Execute PHP Stan
+        run: vendor/bin/phpstan
+
+      - name: Execute Rector
+        run: vendor/bin/rector --dry-run
+
+      - name: Execute PHP Insights
+        run: vendor/bin/phpinsights --disable-security-check --no-interaction

--- a/composer.json
+++ b/composer.json
@@ -22,12 +22,12 @@
     ],
     "require": {
         "php": "^8.2",
-        "illuminate/config": "^11.0|^12.0",
-        "illuminate/console": "^11.0|^12.0",
-        "illuminate/container": "^11.0|^12.0",
-        "illuminate/contracts": "^11.0|^12.0",
-        "illuminate/pipeline": "^11.0|^12.0",
-        "illuminate/support": "^11.0|^12.0"
+        "illuminate/config": "^11.0|^12.0|^13.0",
+        "illuminate/console": "^11.0|^12.0|^13.0",
+        "illuminate/container": "^11.0|^12.0|^13.0",
+        "illuminate/contracts": "^11.0|^12.0|^13.0",
+        "illuminate/pipeline": "^11.0|^12.0|^13.0",
+        "illuminate/support": "^11.0|^12.0|^13.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",
@@ -35,7 +35,7 @@
         "laravel/pint": "^1.2",
         "mockery/mockery": "^1.6.1",
         "nunomaduro/phpinsights": "^2.13",
-        "orchestra/testbench": "^v8.0|^v9.0|^v10.0",
+        "orchestra/testbench": "^v8.0|^v9.0|^v10.0|^v11.0",
         "pestphp/pest": "^2.0|^3.0",
         "pestphp/pest-plugin-laravel": "^2.0|^3.0",
         "rector/rector": "^1.0|^2.0|^3.0",


### PR DESCRIPTION
## Summary
- Widen `illuminate/*` constraints to include `^13.0`
- Widen `orchestra/testbench` to include `^v11.0`
- No code changes required — the package uses stable Console/Pipeline/Config APIs

## Notes
- Laravel 13 requires PHP `^8.3` (this package requires `^8.2`, so users on L13 will already satisfy that)
- Testbench v11 is not yet tagged but the constraint is forward-compatible